### PR TITLE
Update knative-prow to v20210211-72696ce111

### DIFF
--- a/prow/knative/cluster/400-crier.yaml
+++ b/prow/knative/cluster/400-crier.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/crier:v20210211-72696ce111
         args:
         - --pubsub-workers=5 # Arbitrary number of multiplier
         - --blob-storage-workers=1

--- a/prow/knative/cluster/400-deck.yaml
+++ b/prow/knative/cluster/400-deck.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/deck:v20210211-72696ce111
         args:
         - --hook-url=http://hook:8888/plugin-help
         - --tide-url=http://tide/

--- a/prow/knative/cluster/400-ghproxy.yaml
+++ b/prow/knative/cluster/400-ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20210206-3c06bdc6cf
+          image: gcr.io/k8s-prow/ghproxy:v20210211-72696ce111
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/prow/knative/cluster/400-hook.yaml
+++ b/prow/knative/cluster/400-hook.yaml
@@ -39,7 +39,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/hook:v20210211-72696ce111
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/knative/cluster/400-horologium.yaml
+++ b/prow/knative/cluster/400-horologium.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/horologium:v20210211-72696ce111
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/knative/cluster/400-prow-controller-manager.yaml
+++ b/prow/knative/cluster/400-prow-controller-manager.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/prow-controller-manager:v20210211-72696ce111
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/knative/cluster/400-sinker.yaml
+++ b/prow/knative/cluster/400-sinker.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/sinker:v20210211-72696ce111
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/knative/cluster/400-tide.yaml
+++ b/prow/knative/cluster/400-tide.yaml
@@ -51,7 +51,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/tide:v20210211-72696ce111
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/knative/cluster/500-cherrypicker.yaml
+++ b/prow/knative/cluster/500-cherrypicker.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/cherrypicker:v20210211-72696ce111
         args:
         - --dry-run=false
         - --use-prow-assignments=false

--- a/prow/knative/cluster/500-needs-rebase.yaml
+++ b/prow/knative/cluster/500-needs-rebase.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/needs-rebase:v20210211-72696ce111
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/prow/knative/cluster/500-status-reconciler.yaml
+++ b/prow/knative/cluster/500-status-reconciler.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20210206-3c06bdc6cf
+          image: gcr.io/k8s-prow/status-reconciler:v20210211-72696ce111
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/knative/config.yaml
+++ b/prow/knative/config.yaml
@@ -25,10 +25,10 @@ plank:
       grace_period: 15s
       utility_images:
         # Update these versions when updating plank version in cluster.yaml
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20210206-3c06bdc6cf"
-        initupload: "gcr.io/k8s-prow/initupload:v20210206-3c06bdc6cf"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20210206-3c06bdc6cf"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20210206-3c06bdc6cf"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20210211-72696ce111"
+        initupload: "gcr.io/k8s-prow/initupload:v20210211-72696ce111"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20210211-72696ce111"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20210211-72696ce111"
       gcs_configuration:
         bucket: "knative-prow"
         path_strategy: "explicit"

--- a/prow/knative/knative-autobump-config.yaml
+++ b/prow/knative/knative-autobump-config.yaml
@@ -1,13 +1,12 @@
 ---
-gitHubLogin: "google-oss-robot"
-gitHubToken: "/etc/github-token/oauth"
-onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
+gitHubLogin: "mpherman2"
+gitHubToken: "/usr/local/google/home/mpherman/token"
 skipPullRequest: false
-gitHubOrg: "GoogleCloudPlatform"
+gitHubOrg: "mpherman2"
 gitHubRepo: "oss-test-infra"
 remoteName: "oss-test-infra"
 headBranchName: "autobump-knative-prow"
-upstreamURLBase: "https://raw.githubusercontent.com/GoogleCloudPlatform/oss-test-infra/master"
+upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
 includedConfigPaths:
   - "prow/knative/cluster"
 targetVersion: "upstream"

--- a/prow/knative/knative-autobump-config.yaml
+++ b/prow/knative/knative-autobump-config.yaml
@@ -1,0 +1,22 @@
+---
+gitHubLogin: "google-oss-robot"
+gitHubToken: "/etc/github-token/oauth"
+onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
+skipPullRequest: false
+gitHubOrg: "GoogleCloudPlatform"
+gitHubRepo: "oss-test-infra"
+remoteName: "oss-test-infra"
+headBranchName: "autobump-knative-prow"
+upstreamURLBase: "https://raw.githubusercontent.com/GoogleCloudPlatform/oss-test-infra/master"
+includedConfigPaths:
+  - "prow/knative/cluster"
+targetVersion: "upstream"
+extraFiles:
+  - "prow/knative/config.yaml"
+prefixes:
+  - name: "knative-prow"
+    prefix: "gcr.io/k8s-prow/"
+    refConfigFile: "config/prow/cluster/deck_deployment.yaml"
+    repo: "https://github.com/kubernetes/test-infra"
+    summarise: false
+    consistentImages: true

--- a/prow/oss/oss-autobump-config.yaml
+++ b/prow/oss/oss-autobump-config.yaml
@@ -1,0 +1,23 @@
+---
+gitHubLogin: "google-oss-robot"
+gitHubToken: "/etc/github-token/oauth"
+onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
+skipPullRequest: false
+gitHubOrg: "GoogleCloudPlatform"
+gitHubRepo: "oss-test-infra"
+remoteName: "oss-test-infra"
+headBranchName: "autobump-oss-prow"
+upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
+includedConfigPaths:
+  - "prow/knative/cluster"
+targetVersion: "upstream"
+extraFiles:
+  - "prow/knative/config.yaml"
+  - "prow/prowjobs"
+prefixes: 
+  - name: "oss-prow"
+    prefix: "gcr.io/k8s-prow/"
+    repo: "https://github.com/kubernetes/test-infra"
+    refConfigFile: "config/prow/cluster/deck_deployment.yaml"
+    summarise: false
+    consistentImages: true

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -314,36 +314,25 @@ periodics:
     testgrid-num-failures-to-alert: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20210206-3c06bdc6cf
+    - image: gcr.io/k8s-testimages/generic_autobump:v20210126-f503f3e
       command:
-      - /autobump.sh
+      - /generic_autobump
       args:
-      - /etc/github-token/oauth
-      - "Google OSS Prow Robot"
-      - google-oss-robot@google.com
+      - --config=prow/knative/knative-autobump-config.yaml
       volumeMounts:
       - name: github
         mountPath: /etc/github-token
         readOnly: true
-      env:
-      - name: GH_ORG
-        value: GoogleCloudPlatform
-      - name: GH_REPO
-        value: oss-test-infra
-      - name: PROW_CONTROLLER_MANAGER_FILE
-        value: prow/oss/cluster/prow-controller-manager.yaml
-      - name: COMPONENT_FILE_DIR
-        value: prow/oss/cluster
-      - name: CONFIG_PATH
-        value: prow/oss/config.yaml
-      - name: JOB_CONFIG_PATH
-        value: prow/prowjobs
-      - name: PROW_INSTANCE_NAME
-        value: oss-prow
+      - name: ssh
+        mountPath: /root/.ssh
     volumes:
     - name: github
       secret:
         secretName: oauth-token
+    - name: ssh
+      secret:
+        secretName: google-oss-robot-ssh-keys
+        defaultMode: 0400
 - cron: "05 15-23 * * 1-5"  # Run at 7:05-15:05 PST (15:05 UTC) Mon-Fri
   name: testgrid-canary-autobump
   cluster: test-infra-trusted
@@ -393,34 +382,25 @@ periodics:
     testgrid-num-failures-to-alert: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20210206-3c06bdc6cf
+    - image: gcr.io/k8s-testimages/generic_autobump:v20210126-f503f3e
       command:
-      - /autobump.sh
+      - /generic_autobump
       args:
-      - /etc/github-token/oauth
-      - "Google OSS Prow Robot"
-      - google-oss-robot@google.com
+      - --config=prow/knative/knative-autobump-config.yaml
       volumeMounts:
       - name: github
         mountPath: /etc/github-token
         readOnly: true
-      env:
-      - name: GH_ORG
-        value: GoogleCloudPlatform
-      - name: GH_REPO
-        value: oss-test-infra
-      - name: PROW_CONTROLLER_MANAGER_FILE
-        value: prow/knative/cluster/400-prow-controller-manager.yaml
-      - name: COMPONENT_FILE_DIR
-        value: prow/knative/cluster
-      - name: CONFIG_PATH
-        value: prow/knative/config.yaml
-      - name: PROW_INSTANCE_NAME
-        value: knative-prow
+      - name: ssh
+        mountPath: /root/.ssh
     volumes:
     - name: github
       secret:
         secretName: oauth-token
+    - name: ssh
+      secret:
+        secretName: google-oss-robot-ssh-keys
+        defaultMode: 0400
 # ci-oss-test-infra-heartbeat is used for prometheus, alert(s) will be sent
 # if this job hadn't been succeeded for some time
 - cron: "*/3 * * * *" # Every 3 minutes


### PR DESCRIPTION
Multiple distinct knative-prow changes:

Commits | Dates | Images
--- | --- | ---
https://github.com/kubernetes/test-infra/compare/3c06bdc6cf...72696ce111 | 2021&#x2011;02&#x2011;06&nbsp;&#x2192;&nbsp;2021&#x2011;02&#x2011;11 | cherrypicker, clonerefs, crier, deck, entrypoint, ghproxy, hook, horologium, initupload, needs-rebase, prow-controller-manager, sidecar, sinker, status-reconciler, tide



