### PR TITLE
Update oss-prow to v20210215-f94bc1dc87

### DIFF
--- a/prow/knative/knative-autobump-config.yaml
+++ b/prow/knative/knative-autobump-config.yaml
@@ -1,0 +1,22 @@
+---
+gitHubLogin: "google-oss-robot"
+gitHubToken: "/etc/github-token/oauth"
+onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
+skipPullRequest: false
+gitHubOrg: "GoogleCloudPlatform"
+gitHubRepo: "oss-test-infra"
+remoteName: "oss-test-infra"
+headBranchName: "autobump-knative-prow"
+upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
+includedConfigPaths:
+  - "prow/knative/cluster"
+targetVersion: "upstream"
+extraFiles:
+  - "prow/knative/config.yaml"
+prefixes:
+  - name: "knative-prow"
+    prefix: "gcr.io/k8s-prow/"
+    refConfigFile: "config/prow/cluster/deck_deployment.yaml"
+    repo: "https://github.com/kubernetes/test-infra"
+    summarise: false
+    consistentImages: true

--- a/prow/oss/cluster/crier.yaml
+++ b/prow/oss/cluster/crier.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/crier:v20210215-f94bc1dc87
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/prow/oss/cluster/deck.yaml
+++ b/prow/oss/cluster/deck.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/deck:v20210215-f94bc1dc87
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/gerrit.yaml
+++ b/prow/oss/cluster/gerrit.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: gerrit
-        image: gcr.io/k8s-prow/gerrit:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/gerrit:v20210215-f94bc1dc87
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/ghproxy.yaml
+++ b/prow/oss/cluster/ghproxy.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/ghproxy:v20210215-f94bc1dc87
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=49

--- a/prow/oss/cluster/grandmatriarch_default.yaml
+++ b/prow/oss/cluster/grandmatriarch_default.yaml
@@ -69,6 +69,6 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/grandmatriarch:v20210215-f94bc1dc87
         args:
         - http-cookiefile

--- a/prow/oss/cluster/grandmatriarch_test-pods.yaml
+++ b/prow/oss/cluster/grandmatriarch_test-pods.yaml
@@ -74,6 +74,6 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/grandmatriarch:v20210215-f94bc1dc87
         args:
         - http-cookiefile

--- a/prow/oss/cluster/hook.yaml
+++ b/prow/oss/cluster/hook.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/hook:v20210215-f94bc1dc87
         imagePullPolicy: Always
         args:
         - --config-path=/etc/config/config.yaml

--- a/prow/oss/cluster/horologium.yaml
+++ b/prow/oss/cluster/horologium.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/horologium:v20210215-f94bc1dc87
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/prow-controller-manager.yaml
+++ b/prow/oss/cluster/prow-controller-manager.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/prow-controller-manager:v20210215-f94bc1dc87
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/oss/cluster/sinker.yaml
+++ b/prow/oss/cluster/sinker.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: sinker
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/sinker:v20210215-f94bc1dc87
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/cluster/tide.yaml
+++ b/prow/oss/cluster/tide.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20210206-3c06bdc6cf
+        image: gcr.io/k8s-prow/tide:v20210215-f94bc1dc87
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -71,10 +71,10 @@ plank:
       timeout: 7200000000000 # 2h
       grace_period: 15000000000 # 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20210206-3c06bdc6cf"
-        initupload: "gcr.io/k8s-prow/initupload:v20210206-3c06bdc6cf"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20210206-3c06bdc6cf"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20210206-3c06bdc6cf"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20210215-f94bc1dc87"
+        initupload: "gcr.io/k8s-prow/initupload:v20210215-f94bc1dc87"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20210215-f94bc1dc87"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20210215-f94bc1dc87"
       gcs_configuration:
         bucket: "oss-prow"
         path_strategy: "explicit"

--- a/prow/oss/oss-autobump-config.yaml
+++ b/prow/oss/oss-autobump-config.yaml
@@ -1,0 +1,23 @@
+---
+gitHubLogin: "google-oss-robot"
+gitHubToken: "/etc/github-token/oauth"
+onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
+skipPullRequest: false
+gitHubOrg: "GoogleCloudPlatform"
+gitHubRepo: "oss-test-infra"
+remoteName: "oss-test-infra"
+headBranchName: "autobump-oss-prow"
+upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
+includedConfigPaths:
+  - "prow/oss/cluster"
+  - "prow/prowjobs"
+targetVersion: "upstream"
+extraFiles:
+  - "prow/oss/config.yaml"
+prefixes: 
+  - name: "oss-prow"
+    prefix: "gcr.io/k8s-prow/"
+    repo: "https://github.com/kubernetes/test-infra"
+    refConfigFile: "config/prow/cluster/deck_deployment.yaml"
+    summarise: false
+    consistentImages: true

--- a/prow/oss/oss-autobump-config.yaml
+++ b/prow/oss/oss-autobump-config.yaml
@@ -1,9 +1,8 @@
 ---
-gitHubLogin: "google-oss-robot"
-gitHubToken: "/etc/github-token/oauth"
-onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
+gitHubLogin: "mpherman2"
+gitHubToken: "/usr/local/google/home/mpherman/token"
 skipPullRequest: false
-gitHubOrg: "GoogleCloudPlatform"
+gitHubOrg: "mpherman2"
 gitHubRepo: "oss-test-infra"
 remoteName: "oss-test-infra"
 headBranchName: "autobump-oss-prow"

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -314,36 +314,25 @@ periodics:
     testgrid-num-failures-to-alert: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20210206-3c06bdc6cf
+    - image: gcr.io/k8s-testimages/generic_autobump:v20210126-f503f3e
       command:
-      - /autobump.sh
+      - /generic_autobump
       args:
-      - /etc/github-token/oauth
-      - "Google OSS Prow Robot"
-      - google-oss-robot@google.com
+      - --config=prow/knative/knative-autobump-config.yaml
       volumeMounts:
       - name: github
         mountPath: /etc/github-token
         readOnly: true
-      env:
-      - name: GH_ORG
-        value: GoogleCloudPlatform
-      - name: GH_REPO
-        value: oss-test-infra
-      - name: PROW_CONTROLLER_MANAGER_FILE
-        value: prow/oss/cluster/prow-controller-manager.yaml
-      - name: COMPONENT_FILE_DIR
-        value: prow/oss/cluster
-      - name: CONFIG_PATH
-        value: prow/oss/config.yaml
-      - name: JOB_CONFIG_PATH
-        value: prow/prowjobs
-      - name: PROW_INSTANCE_NAME
-        value: oss-prow
+      - name: ssh
+        mountPath: /root/.ssh
     volumes:
     - name: github
       secret:
         secretName: oauth-token
+    - name: ssh
+      secret:
+        secretName: google-oss-robot-ssh-keys
+        defaultMode: 0400
 - cron: "05 15-23 * * 1-5"  # Run at 7:05-15:05 PST (15:05 UTC) Mon-Fri
   name: testgrid-canary-autobump
   cluster: test-infra-trusted
@@ -393,34 +382,25 @@ periodics:
     testgrid-num-failures-to-alert: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20210206-3c06bdc6cf
+    - image: gcr.io/k8s-testimages/generic_autobump:v20210126-f503f3e
       command:
-      - /autobump.sh
+      - /generic_autobump
       args:
-      - /etc/github-token/oauth
-      - "Google OSS Prow Robot"
-      - google-oss-robot@google.com
+      - --config=prow/knative/knative-autobump-config.yaml
       volumeMounts:
       - name: github
         mountPath: /etc/github-token
         readOnly: true
-      env:
-      - name: GH_ORG
-        value: GoogleCloudPlatform
-      - name: GH_REPO
-        value: oss-test-infra
-      - name: PROW_CONTROLLER_MANAGER_FILE
-        value: prow/knative/cluster/400-prow-controller-manager.yaml
-      - name: COMPONENT_FILE_DIR
-        value: prow/knative/cluster
-      - name: CONFIG_PATH
-        value: prow/knative/config.yaml
-      - name: PROW_INSTANCE_NAME
-        value: knative-prow
+      - name: ssh
+        mountPath: /root/.ssh
     volumes:
     - name: github
       secret:
         secretName: oauth-token
+    - name: ssh
+      secret:
+        secretName: google-oss-robot-ssh-keys
+        defaultMode: 0400
 # ci-oss-test-infra-heartbeat is used for prometheus, alert(s) will be sent
 # if this job hadn't been succeeded for some time
 - cron: "*/3 * * * *" # Every 3 minutes

--- a/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
+++ b/prow/prowjobs/GoogleCloudPlatform/oss-test-infra/gcp-oss-test-infra-config.yaml
@@ -7,7 +7,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: gcr.io/k8s-prow/checkconfig:v20210206-3c06bdc6cf
+        - image: gcr.io/k8s-prow/checkconfig:v20210215-f94bc1dc87
           imagePullPolicy: Always
           command:
             - /checkconfig
@@ -75,7 +75,7 @@ presubmits:
       base_ref: master
     spec:
       containers:
-        - image: gcr.io/k8s-prow/checkconfig:v20210206-3c06bdc6cf
+        - image: gcr.io/k8s-prow/checkconfig:v20210215-f94bc1dc87
           imagePullPolicy: Always
           command:
             - /checkconfig
@@ -181,7 +181,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-prow/hmac:v20210206-3c06bdc6cf
+      - image: gcr.io/k8s-prow/hmac:v20210215-f94bc1dc87
         command:
         - /hmac
         args:


### PR DESCRIPTION
Multiple distinct oss-prow changes:

Commits | Dates | Images
--- | --- | ---
https://github.com/kubernetes/test-infra/compare/3c06bdc6cf...f94bc1dc87 | 2021&#x2011;02&#x2011;06&nbsp;&#x2192;&nbsp;2021&#x2011;02&#x2011;15 | checkconfig, clonerefs, crier, deck, entrypoint, gerrit, ghproxy, grandmatriarch, hmac, hook, horologium, initupload, prow-controller-manager, sidecar, sinker, tide



